### PR TITLE
MPI+X Cholesky

### DIFF
--- a/micro-benches/2-level/cholesky.sh
+++ b/micro-benches/2-level/cholesky.sh
@@ -1,0 +1,49 @@
+#! /usr/bin/env bash
+
+source ./utils.sh
+
+parse_args "$@"
+
+# Benchmark name 
+target_name="cholesky_omptasks"
+
+print_info ${target_name}
+
+cholesky_dir=${target_name}/detach-deps
+cholesky_patch_file=${CORRBENCH_mutate_file}
+
+if [[ ${do_download} == "yes" ]]; then
+  echo "Download ${target_name}"
+  https://github.com/RWTH-HPC/${target_name}.git
+fi
+
+if [[ ${do_build} == "yes" ]]; then
+	echo "Building application"
+	cd ${cholesky_dir}
+	cp ../../patches/Makefile.cholesky ./Makefile
+
+	# apply patches and build the mutations
+  if [[ -n "${cholesky_patch_file}" ]]; then
+    # Init git repo, add everything apply patch
+    echo -e "Applying the patch file: " ${cholesky_patch_file}
+    git apply ${cholesky_patch_file}
+  else
+    echo "Applying no mutation"
+  fi
+
+  make MPICXX="${mpi_cxx}" ${make_target} -j ${n_procs}
+  cd ../../..
+fi
+
+if [[ "${do_run}" == "yes" ]]; then
+	echo "Running application"
+	cd ${cholesky_dir}
+    time ${mpi_run} -np ${mpi_procs} ./ch_clang_fine 1024 128 1
+	cd ../..
+fi
+
+if [[ "${do_clean}" == "yes" ]]; then
+	echo "Removing directory ${cholesky_dir}"
+	#rm -rf ${cholesky_dir} 
+fi
+

--- a/micro-benches/2-level/cholesky.sh
+++ b/micro-benches/2-level/cholesky.sh
@@ -31,7 +31,7 @@ if [[ ${do_build} == "yes" ]]; then
     echo "Applying no mutation"
   fi
 
-  make MPICXX="${mpi_cxx}" ${make_target} -j ${n_procs}
+  make MPICXX="${mpi_cxx}" MPICC="${mpi_cc}" ${make_target} -j ${n_procs}
   cd ../../..
 fi
 

--- a/micro-benches/2-level/cholesky.sh
+++ b/micro-benches/2-level/cholesky.sh
@@ -14,15 +14,15 @@ cholesky_patch_file=${CORRBENCH_mutate_file}
 
 if [[ ${do_download} == "yes" ]]; then
   echo "Download ${target_name}"
-  https://github.com/RWTH-HPC/${target_name}.git
+  git clone -b mpi-detach https://github.com/RWTH-HPC/${target_name}.git
 fi
 
 if [[ ${do_build} == "yes" ]]; then
-	echo "Building application"
-	cd ${cholesky_dir}
-	cp ../../patches/Makefile.cholesky ./Makefile
+  echo "Building application"
+  cd ${cholesky_dir}
+  cp ../../patches/Makefile.cholesky ./Makefile
 
-	# apply patches and build the mutations
+  # apply patches and build the mutations
   if [[ -n "${cholesky_patch_file}" ]]; then
     # Init git repo, add everything apply patch
     echo -e "Applying the patch file: " ${cholesky_patch_file}
@@ -36,14 +36,15 @@ if [[ ${do_build} == "yes" ]]; then
 fi
 
 if [[ "${do_run}" == "yes" ]]; then
-	echo "Running application"
-	cd ${cholesky_dir}
-    time ${mpi_run} -np ${mpi_procs} ./ch_clang_fine 1024 128 1
-	cd ../..
+  echo "Running application"
+  cd ${cholesky_dir}
+  export MPIX_DETACH=progress
+  time ${mpi_run} -np ${mpi_procs} ./cholesky_clang_fine 4096 128 1
+  cd ../..
 fi
 
 if [[ "${do_clean}" == "yes" ]]; then
-	echo "Removing directory ${cholesky_dir}"
-	#rm -rf ${cholesky_dir} 
+  echo "Removing directory ${target_name}"
+  rm -rf ${target_name}
 fi
 

--- a/micro-benches/2-level/patches/Makefile.cholesky
+++ b/micro-benches/2-level/patches/Makefile.cholesky
@@ -2,25 +2,33 @@ TARGET=clang
 CC ?= OMPI_CC=clang mpicc
 CXX ?= OMPI_CXX=clang++ mpic++
 MPICXX ?= $(CXX)
+MPICC ?= $(CC)
 MKLROOT ?= /shared/apps/intel/2020.4/mkl
 CFLAGS  += -I$(MKLROOT)/include -O3 -I./ -std=gnu99  -fopenmp -g -fopenmp-version=50
-LDFLAGS += -fopenmp -fopenmp-version=50 -L$(MKLROOT)/lib/intel64 -Wl,--rpath,$(MKLROOT)/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -lm -ldl
+LDFLAGS += -fopenmp -L$(MKLROOT)/lib/intel64 -Wl,--rpath,$(MKLROOT)/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -lm -ldl
+DETACH_LDFLAGS = -L. -Wl,--rpath,$(PWD) -ldetach_$(TARGET)
 
 
 SRC=ch_ompss.c ch_common.c
 OBJECTS = $(SRC:.c=.o)
 
+DETACH_SRC=detach.cpp
+DETACH_OBJ=$(DETACH_SRC:.cpp=.o)
 
 all : cholesky_$(TARGET)_fine
 
 .c.o: $(SRC)
-	$(CC) $(CFLAGS) -c $< -o $@ 
+	$(MPICC) $(CFLAGS) -c $< -o $@ 
 
-cholesky_$(TARGET)_fine: $(OBJECTS)
-	$(CC) $(OBJECTS) $(LDFLAGS) -o $@
+cholesky_$(TARGET)_fine: $(OBJECTS) libdetach_$(TARGET).so
+	$(MPICC) $(OBJECTS) $(LDFLAGS) $(DETACH_LDFLAGS) -o $@
+
+.cpp.o: $(DETACH_SRC)
+	$(MPICXX) -DOMPI_SKIP_MPICXX=1 -g -O3 -std=c++14 -fPIC -c $< -o $@
+
+libdetach_$(TARGET).so: $(DETACH_OBJ)
+	$(MPICXX) -shared $< -o $@
 
 clean:
-	rm -f *.o cholesky_$(TARGET)_fine *.so
+	rm -f *.o cholesky_$(TARGET)_fine libdetach_$(TARGET).so
 
-cleanall: 
-	rm -f *.o cholesky_*_fine *.so

--- a/micro-benches/2-level/patches/Makefile.cholesky
+++ b/micro-benches/2-level/patches/Makefile.cholesky
@@ -1,0 +1,26 @@
+TARGET=clang
+CC ?= OMPI_CC=clang mpicc
+CXX ?= OMPI_CXX=clang++ mpic++
+MPICXX ?= $(CXX)
+MKLROOT ?= /shared/apps/intel/2020.4/mkl
+CFLAGS  += -I$(MKLROOT)/include -O3 -I./ -std=gnu99  -fopenmp -g -fopenmp-version=50
+LDFLAGS += -fopenmp -fopenmp-version=50 -L$(MKLROOT)/lib/intel64 -Wl,--rpath,$(MKLROOT)/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -lm -ldl
+
+
+SRC=ch_ompss.c ch_common.c
+OBJECTS = $(SRC:.c=.o)
+
+
+all : cholesky_$(TARGET)_fine
+
+.c.o: $(SRC)
+	$(CC) $(CFLAGS) -c $< -o $@ 
+
+cholesky_$(TARGET)_fine: $(OBJECTS)
+	$(CC) $(OBJECTS) $(LDFLAGS) -o $@
+
+clean:
+	rm -f *.o cholesky_$(TARGET)_fine *.so
+
+cleanall: 
+	rm -f *.o cholesky_*_fine *.so

--- a/micro-benches/2-level/patches/Makefile.cholesky
+++ b/micro-benches/2-level/patches/Makefile.cholesky
@@ -1,19 +1,25 @@
 TARGET=clang
-CC ?= OMPI_CC=clang mpicc
-CXX ?= OMPI_CXX=clang++ mpic++
-MPICXX ?= $(CXX)
-MPICC ?= $(CC)
+MPICC ?= OMPI_CC=clang mpicc
+MPICXX ?= OMPI_CXX=clang++ mpic++
 MKLROOT ?= /shared/apps/intel/2020.4/mkl
 CFLAGS  += -I$(MKLROOT)/include -O3 -I./ -std=gnu99  -fopenmp -g -fopenmp-version=50
 LDFLAGS += -fopenmp -L$(MKLROOT)/lib/intel64 -Wl,--rpath,$(MKLROOT)/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lpthread -lm -ldl
 DETACH_LDFLAGS = -L. -Wl,--rpath,$(PWD) -ldetach_$(TARGET)
-
+DETACH_CXXFLAGS = -DOMPI_SKIP_MPICXX=1 -g -O3 -std=c++14
 
 SRC=ch_ompss.c ch_common.c
 OBJECTS = $(SRC:.c=.o)
 
 DETACH_SRC=detach.cpp
 DETACH_OBJ=$(DETACH_SRC:.cpp=.o)
+
+TIDY_OBJECTS_C = $(SRC:.c=.ct)
+TIDY_OBJECTS_CPP = $(DETACH_SRC:.cpp=.cppt)
+TIDY_MPI_CFLAGS = $(shell mpicc --showme:compile)
+TIDY_MPI_CXXFLAGS = $(shell mpicxx --showme:compile)
+
+BC_OBJECTS_C = $(SRC:.c=.bc)
+BC_OBJECTS_CPP = $(DETACH_SRC:.cpp=.bcpp)
 
 all : cholesky_$(TARGET)_fine
 
@@ -24,11 +30,31 @@ cholesky_$(TARGET)_fine: $(OBJECTS) libdetach_$(TARGET).so
 	$(MPICC) $(OBJECTS) $(LDFLAGS) $(DETACH_LDFLAGS) -o $@
 
 .cpp.o: $(DETACH_SRC)
-	$(MPICXX) -DOMPI_SKIP_MPICXX=1 -g -O3 -std=c++14 -fPIC -c $< -o $@
+	$(MPICXX) $(DETACH_CXXFLAGS) -fPIC -c $< -o $@
 
 libdetach_$(TARGET).so: $(DETACH_OBJ)
 	$(MPICXX) -shared $< -o $@
 
+$(TIDY_OBJECTS_C): %.ct: %.c
+	clang-tidy $< -checks='-*,*mpi*' -- $(TIDY_MPI_CFLAGS) $(CFLAGS)
+
+$(TIDY_OBJECTS_CPP): %.cppt: %.cpp
+	clang-tidy $< -checks='-*,*mpi*' -- $(TIDY_MPI_CXXFLAGS) $(DETACH_CXXFLAGS)
+
+tidy-target: $(TIDY_OBJECTS_CPP) $(TIDY_OBJECTS_C)
+	@echo "Running Clang Tidy"
+	@echo "processed $(TIDY_OBJECTS_C) $(TIDY_OBJECTS_CPP)"
+
+$(BC_OBJECTS_C): %.bc: %.c
+	clang -emit-llvm $(CFLAGS) $(TIDY_MPI_CFLAGS) -c $< -o $@
+
+$(BC_OBJECTS_CPP): %.bcpp: %.cpp
+	clang++ -emit-llvm $(DETACH_CXXFLAGS) $(TIDY_MPI_CXXFLAGS) -c $< -o $@
+
+parcoach-target: $(BC_OBJECTS_C) $(BC_OBJECTS_CPP)
+	llvm-link $(BC_OBJECTS_C) $(BC_OBJECTS_CPP) -o cholesky_$(TARGET)_fine.bc
+	opt -load $(PARCOACH_ROOT)/lib/aSSA.* -parcoach -check-mpi cholesky_$(TARGET)_fine.bc
+
 clean:
-	rm -f *.o cholesky_$(TARGET)_fine libdetach_$(TARGET).so
+	rm -f *.o cholesky_$(TARGET)_fine libdetach_$(TARGET).so *.bc *.bcpp
 


### PR DESCRIPTION
Cholesky solver with MPI + OMP Tasks.

### TODO
Mutations, e.g., remove taskdeps.

### Usage
Usage requires OpenMP 5, example:

```
module load llvm/11
module load openmp/12.0.1
module load openmpi/4.0.3
export MPICXX="OMPI_CXX=clang++ mpicxx"
export MPICC="OMPI_CC=clang mpicc"

./cholesky download
./cholesky build
```