### PR TITLE
Set of conflicting MPI calls

### DIFF
--- a/micro-benches/0-level/openmp/data_race/info_set.c
+++ b/micro-benches/0-level/openmp/data_race/info_set.c
@@ -6,10 +6,7 @@
 #include <stdlib.h>
 
 // Using conflicting MPI calls on MPI_Info:
-// Setting MPI_Info (marker "A") should not happen concurrently from different threads according to the standard.
-
-#define BUFFER_LENGTH_INT 10000
-#define BUFFER_LENGTH_BYTE (BUFFER_LENGTH_INT * sizeof(int))
+// Concurrently setting MPI_Info (marker "A") is a data race.
 
 #define NUM_THREADS 2
 

--- a/micro-benches/0-level/openmp/ordering/derived_datatype.c
+++ b/micro-benches/0-level/openmp/ordering/derived_datatype.c
@@ -4,7 +4,9 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-// Using conflicting MPI calls on MPI_Info:
+// Using conflicting MPI calls for derived datatype:
+// MPI_Send (marker "A") with a derived datatype may happen after MPI_Type_free on the same datatype (marker "B"), which
+// is errorneous.
 
 #define BUFFER_LENGTH_INT 2
 #define BUFFER_LENGTH_BYTE (BUFFER_LENGTH_INT * sizeof(int))

--- a/micro-benches/0-level/openmp/ordering/derived_datatype.c
+++ b/micro-benches/0-level/openmp/ordering/derived_datatype.c
@@ -1,0 +1,60 @@
+#include "nondeterminism.h"
+
+#include <mpi.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+// Using conflicting MPI calls on MPI_Info:
+
+#define BUFFER_LENGTH_INT 2
+#define BUFFER_LENGTH_BYTE (BUFFER_LENGTH_INT * sizeof(int))
+
+#define NUM_THREADS 2
+
+int main(int argc, char *argv[]) {
+  int provided;
+  const int requested = MPI_THREAD_MULTIPLE;
+
+  MPI_Init_thread(&argc, &argv, requested, &provided);
+  if (provided < requested) {
+    has_error_manifested(false);
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+
+  int size;
+  int rank;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  int recv_data[BUFFER_LENGTH_INT];
+  int send_data[BUFFER_LENGTH_INT];
+  MPI_Request req;
+
+  MPI_Datatype mult_ints_dtype;
+  MPI_Type_contiguous(BUFFER_LENGTH_INT, MPI_INT, &mult_ints_dtype);
+  MPI_Type_commit(&mult_ints_dtype);
+
+  fill_message_buffer(recv_data, BUFFER_LENGTH_BYTE, 6);
+  fill_message_buffer(send_data, BUFFER_LENGTH_BYTE, 1);
+
+  MPI_Irecv(recv_data, 1, mult_ints_dtype, size - rank - 1, 1, MPI_COMM_WORLD, &req);
+
+#pragma omp parallel num_threads(NUM_THREADS)
+  {
+#pragma omp single nowait
+    {
+      us_sleep(1);
+      MPI_Send(send_data, 1, mult_ints_dtype, size - rank - 1, 1, MPI_COMM_WORLD); /* A */
+    }
+#pragma omp single
+    { MPI_Type_free(&mult_ints_dtype); /* B */ }
+  }
+
+  MPI_Wait(&req, MPI_STATUS_IGNORE);
+
+  MPI_Finalize();
+
+  has_error_manifested(true);
+
+  return 0;
+}

--- a/micro-benches/0-level/openmp/ordering/info_free.c
+++ b/micro-benches/0-level/openmp/ordering/info_free.c
@@ -10,9 +10,6 @@
 // Idea taken from: "Thread-safety in an MPI implementation: Requirements and analysis" by
 // W. Gropp and R. Thakur. DOI: 10.1016/j.parco.2007.07.002
 
-#define BUFFER_LENGTH_INT 10000
-#define BUFFER_LENGTH_BYTE (BUFFER_LENGTH_INT * sizeof(int))
-
 #define NUM_THREADS 2
 
 int main(int argc, char *argv[]) {

--- a/micro-benches/0-level/openmp/ordering/info_free.c
+++ b/micro-benches/0-level/openmp/ordering/info_free.c
@@ -1,0 +1,49 @@
+#include "nondeterminism.h"
+
+#include <mpi.h>
+#include <omp.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+// Using conflicting MPI calls on MPI_Info:
+// Setting MPI_Info (marker "A") may happen concurrently with MPI_Info_free (marker "B").
+// Idea taken from: "Thread-safety in an MPI implementation: Requirements and analysis" by
+// W. Gropp and R. Thakur. DOI: 10.1016/j.parco.2007.07.002
+
+#define BUFFER_LENGTH_INT 10000
+#define BUFFER_LENGTH_BYTE (BUFFER_LENGTH_INT * sizeof(int))
+
+#define NUM_THREADS 2
+
+int main(int argc, char *argv[]) {
+  int provided;
+  const int requested = MPI_THREAD_MULTIPLE;
+
+  MPI_Init_thread(&argc, &argv, requested, &provided);
+  if (provided < requested) {
+    has_error_manifested(false);
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+
+  int size;
+  int rank;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  MPI_Info info_obj;
+  MPI_Info_create(&info_obj);
+
+#pragma omp parallel num_threads(NUM_THREADS)
+  {
+#pragma omp single nowait
+    { MPI_Info_set(info_obj, "Hello", "World"); /* A */ }
+#pragma omp single
+    { MPI_Info_free(&info_obj); /* B */ }
+  }
+
+  MPI_Finalize();
+
+  has_error_manifested(true);
+
+  return 0;
+}

--- a/micro-benches/0-level/openmp/ordering/info_update.c
+++ b/micro-benches/0-level/openmp/ordering/info_update.c
@@ -1,0 +1,45 @@
+#include "nondeterminism.h"
+
+#include <mpi.h>
+#include <omp.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+// Using conflicting MPI calls on MPI_Info:
+// Setting MPI_Info (marker "A") should not happen concurrently from different threads according to the standard.
+
+#define BUFFER_LENGTH_INT 10000
+#define BUFFER_LENGTH_BYTE (BUFFER_LENGTH_INT * sizeof(int))
+
+#define NUM_THREADS 2
+
+int main(int argc, char *argv[]) {
+  int provided;
+  const int requested = MPI_THREAD_MULTIPLE;
+
+  MPI_Init_thread(&argc, &argv, requested, &provided);
+  if (provided < requested) {
+    has_error_manifested(false);
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+
+  int size;
+  int rank;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  MPI_Info info_obj;
+  MPI_Info_create(&info_obj);
+
+  const char *values[2] = {"Thread 1", "Thread 2"};
+
+#pragma omp parallel num_threads(NUM_THREADS)
+  { MPI_Info_set(info_obj, "Hello", values[omp_get_thread_num()]); /* A */ }
+
+  MPI_Info_free(&info_obj);
+  MPI_Finalize();
+
+  has_error_manifested(true);
+
+  return 0;
+}


### PR DESCRIPTION
- Derived datatype is free'd (before\while use)
- MPI_Info free before/while use
- MPI_Info set concurrently (illegal)