### PR TITLE
OpenMP private variable

### DIFF
--- a/micro-benches/0-level/openmp/memory/private_after_send.c
+++ b/micro-benches/0-level/openmp/memory/private_after_send.c
@@ -1,0 +1,53 @@
+#include "nondeterminism.h"
+
+#include <mpi.h>
+#include <omp.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+// A private variable (uninitialized in parallel region, marker "A") may cause undefined behavior when send (marker "B")
+// (and used in a different process).
+
+#define BUFFER_LENGTH_INT 1
+#define BUFFER_LENGTH_BYTE (BUFFER_LENGTH_INT * sizeof(int))
+
+#define NUM_THREADS 2
+
+int main(int argc, char *argv[]) {
+  int provided;
+  const int requested = MPI_THREAD_FUNNELED;
+
+  MPI_Init_thread(&argc, &argv, requested, &provided);
+  if (provided < requested) {
+    has_error_manifested(false);
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+
+  int size;
+  int rank;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  int recv_data[BUFFER_LENGTH_INT];
+  fill_message_buffer(recv_data, BUFFER_LENGTH_BYTE, 1);
+
+  if (rank == 0) {
+    int private_data = rank;
+#pragma omp parallel num_threads(NUM_THREADS) default(shared) private(private_data) /* A */
+    {
+#pragma omp master
+      {
+        MPI_Send(&private_data, BUFFER_LENGTH_INT, MPI_INT, size - rank - 1, 1, MPI_COMM_WORLD); /* B */
+        private_data = rank;
+      }
+    }
+  } else if (rank == 1) {
+    MPI_Recv(recv_data, BUFFER_LENGTH_INT, MPI_INT, size - rank - 1, 1, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+    has_error_manifested(recv_data[0] != 0);
+  }
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/micro-benches/0-level/openmp/memory/private_after_send.c
+++ b/micro-benches/0-level/openmp/memory/private_after_send.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[]) {
 #pragma omp master
       {
         MPI_Send(&private_data, BUFFER_LENGTH_INT, MPI_INT, size - rank - 1, 1, MPI_COMM_WORLD); /* B */
-        private_data = rank;
+        private_data = rank; // initialization of private variable only happend after send
       }
     }
   } else if (rank == 1) {

--- a/micro-benches/0-level/openmp/memory/private_bcast.c
+++ b/micro-benches/0-level/openmp/memory/private_bcast.c
@@ -1,0 +1,45 @@
+#include "nondeterminism.h"
+
+#include <mpi.h>
+#include <omp.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+// A private variable (uninitialized in parallel region, marker "A") may cause undefined behavior when broadcasted
+// (marker "B") (and used in a different process).
+
+#define NUM_THREADS 2
+
+int main(int argc, char *argv[]) {
+  int provided;
+  const int requested = MPI_THREAD_FUNNELED;
+
+  MPI_Init_thread(&argc, &argv, requested, &provided);
+  if (provided < requested) {
+    has_error_manifested(false);
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+
+  int size;
+  int rank;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  int private_data = rank;
+
+#pragma omp parallel num_threads(NUM_THREADS) default(shared) private(private_data) /* A */
+  {
+#pragma omp master
+    { MPI_Bcast(&private_data, 1, MPI_INT, 0, MPI_COMM_WORLD); /* B */ }
+  }
+
+  if (rank == 1) {
+    has_error_manifested(private_data != 0);
+  }
+
+  has_error_manifested(true);
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/micro-benches/0-level/openmp/memory/private_ibcast.c
+++ b/micro-benches/0-level/openmp/memory/private_ibcast.c
@@ -1,0 +1,48 @@
+#include "nondeterminism.h"
+
+#include <mpi.h>
+#include <omp.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+// A private variable (uninitialized in parallel region, marker "A") may cause undefined behavior when broadcasted
+// (marker "B") (and used in a different process).
+
+#define NUM_THREADS 2
+
+int main(int argc, char *argv[]) {
+  int provided;
+  const int requested = MPI_THREAD_FUNNELED;
+
+  MPI_Init_thread(&argc, &argv, requested, &provided);
+  if (provided < requested) {
+    has_error_manifested(false);
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+
+  int size;
+  int rank;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  MPI_Request req;
+  int private_data = rank;
+
+#pragma omp parallel num_threads(NUM_THREADS) default(shared) private(private_data) /* A */
+  {
+#pragma omp master
+    { MPI_Ibcast(&private_data, 1, MPI_INT, 0, MPI_COMM_WORLD, &req); /* B */ }
+  }
+
+  MPI_Wait(&req, MPI_STATUS_IGNORE);
+
+  if (rank == 1) {
+    has_error_manifested(private_data != 0);
+  }
+
+  has_error_manifested(true);
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/micro-benches/0-level/openmp/memory/private_isend.c
+++ b/micro-benches/0-level/openmp/memory/private_isend.c
@@ -1,0 +1,53 @@
+#include "nondeterminism.h"
+
+#include <mpi.h>
+#include <omp.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+// A private variable (uninitialized in parallel region, marker "A") may cause undefined behavior when send (marker "B")
+// (and used in a different process).
+
+#define BUFFER_LENGTH_INT 1
+#define BUFFER_LENGTH_BYTE (BUFFER_LENGTH_INT * sizeof(int))
+
+#define NUM_THREADS 2
+
+int main(int argc, char *argv[]) {
+  int provided;
+  const int requested = MPI_THREAD_FUNNELED;
+
+  MPI_Init_thread(&argc, &argv, requested, &provided);
+  if (provided < requested) {
+    has_error_manifested(false);
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+
+  int size;
+  int rank;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  int recv_data[BUFFER_LENGTH_INT];
+  fill_message_buffer(recv_data, BUFFER_LENGTH_BYTE, 1);
+
+  if (rank == 0) {
+    MPI_Request send_req;
+    int private_data = rank;
+
+#pragma omp parallel num_threads(NUM_THREADS) default(shared) private(private_data) /* A */
+    {
+#pragma omp master
+      { MPI_Isend(&private_data, BUFFER_LENGTH_INT, MPI_INT, size - rank - 1, 1, MPI_COMM_WORLD, &send_req); /* B */ }
+    }
+    MPI_Wait(&send_req, MPI_STATUS_IGNORE);
+  } else if (rank == 1) {
+    MPI_Recv(recv_data, BUFFER_LENGTH_INT, MPI_INT, size - rank - 1, 1, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+    has_error_manifested(recv_data[0] != 0);
+  }
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/micro-benches/0-level/openmp/memory/private_send.c
+++ b/micro-benches/0-level/openmp/memory/private_send.c
@@ -1,0 +1,51 @@
+#include "nondeterminism.h"
+
+#include <mpi.h>
+#include <omp.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+// A private variable (uninitialized in parallel region, marker "A") may cause undefined behavior when send (marker "B")
+// (and used in a different process).
+
+#define BUFFER_LENGTH_INT 1
+#define BUFFER_LENGTH_BYTE (BUFFER_LENGTH_INT * sizeof(int))
+
+#define NUM_THREADS 2
+
+int main(int argc, char *argv[]) {
+  int provided;
+  const int requested = MPI_THREAD_FUNNELED;
+
+  MPI_Init_thread(&argc, &argv, requested, &provided);
+  if (provided < requested) {
+    has_error_manifested(false);
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+
+  int size;
+  int rank;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  int recv_data[BUFFER_LENGTH_INT];
+  fill_message_buffer(recv_data, BUFFER_LENGTH_BYTE, 1);
+
+  if (rank == 0) {
+    int private_data = rank;
+
+#pragma omp parallel num_threads(NUM_THREADS) default(shared) private(private_data) /* A */
+    {
+#pragma omp master
+      { MPI_Send(&private_data, BUFFER_LENGTH_INT, MPI_INT, size - rank - 1, 1, MPI_COMM_WORLD); /* B */ }
+    }
+  } else if (rank == 1) {
+    MPI_Recv(recv_data, BUFFER_LENGTH_INT, MPI_INT, size - rank - 1, 1, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+    has_error_manifested(recv_data[0] != 0);
+  }
+
+  MPI_Finalize();
+
+  return 0;
+}


### PR DESCRIPTION
Sending OpenMP private variables (uninitialized values in parallel region) may cause UB.

The `has_error_manifested` checks may trigger rarely (if at all?) for some tests.