### PR TITLE
Fix unrelated issues in test cases

### DIFF
--- a/micro-benches/0-level/coll/ArgError-MPIAllgather-Communicator-1.c
+++ b/micro-benches/0-level/coll/ArgError-MPIAllgather-Communicator-1.c
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
   MPI_Allgather(&local_sum, 1, MPI_INT, global_sum, 1, MPI_INT, null_comm);
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum);
+    printf("Result: %d", global_sum[0]);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/ArgError-MPIAllgather-Count-1.c
+++ b/micro-benches/0-level/coll/ArgError-MPIAllgather-Count-1.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   MPI_Allgather(&local_sum, 2, MPI_INT, global_sum, 2, MPI_INT, MPI_COMM_WORLD);
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum);
+    printf("Result: %d", global_sum[0]);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/ArgError-MPIAllgather-Count-3.c
+++ b/micro-benches/0-level/coll/ArgError-MPIAllgather-Count-3.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   MPI_Allgather(&local_sum, -1, MPI_INT, global_sum, 2, MPI_INT, MPI_COMM_WORLD);
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum);
+    printf("Result: %d", global_sum[0]);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/ArgError-MPIAllgather-Count-4.c
+++ b/micro-benches/0-level/coll/ArgError-MPIAllgather-Count-4.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   MPI_Allgather(&local_sum, 1, MPI_INT, global_sum, -1, MPI_INT, MPI_COMM_WORLD);
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum);
+    printf("Result: %d", global_sum[0]);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/ArgError-MPIAllgather-RecvBuffer-2.c
+++ b/micro-benches/0-level/coll/ArgError-MPIAllgather-RecvBuffer-2.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   MPI_Allgather(&local_sum, 1, MPI_INT, global_sum, 1, MPI_INT, MPI_COMM_WORLD);
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum);
+    printf("Result: %d", global_sum[0]);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/ArgError-MPIAllgather-Type-1.c
+++ b/micro-benches/0-level/coll/ArgError-MPIAllgather-Type-1.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   MPI_Allgather(&local_sum, 1, MPI_DOUBLE, global_sum, 1, MPI_INT, MPI_COMM_WORLD);
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum);
+    printf("Result: %d", global_sum[0]);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/ArgError-MPIAllgather-Type-2.c
+++ b/micro-benches/0-level/coll/ArgError-MPIAllgather-Type-2.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   MPI_Allgather(&local_sum, 1, MPI_INT, global_sum, 1, MPI_DOUBLE, MPI_COMM_WORLD);
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum);
+    printf("Result: %d", global_sum[0]);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/ArgError-MPIAllgather-Type-3.c
+++ b/micro-benches/0-level/coll/ArgError-MPIAllgather-Type-3.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   MPI_Allgather(&local_sum, 1, MPI_DOUBLE, global_sum, 1, MPI_DOUBLE, MPI_COMM_WORLD);
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum);
+    printf("Result: %d", global_sum[0]);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/ArgError-MPIAllgather-Type-4.c
+++ b/micro-benches/0-level/coll/ArgError-MPIAllgather-Type-4.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   MPI_Allgather(&local_sum, 1, MPI_UNSIGNED, global_sum, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum);
+    printf("Result: %d", global_sum[0]);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/ArgError-MPIReduce-Communicator-1.c
+++ b/micro-benches/0-level/coll/ArgError-MPIReduce-Communicator-1.c
@@ -15,7 +15,7 @@ int main(int argc, char *argv[]) {
   MPI_Comm_size(MPI_COMM_WORLD, &numProcs);
   MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
 
-  MPI_Comm *comm = NULL;
+  MPI_Comm comm = NULL;
   MPI_Reduce(&local_sum, &global_sum, 1, MPI_INT, MPI_SUM, 0, comm);
 
   if (myRank == 0) {

--- a/micro-benches/0-level/coll/ArgError-MPIReduce-Count-3.c
+++ b/micro-benches/0-level/coll/ArgError-MPIReduce-Count-3.c
@@ -2,26 +2,26 @@
 #include <stddef.h>
 #include <stdio.h>
 /*
- * Too many elements in Reduce call. (line 20)
+ * Reduce call data types do not match. (line 20)
  */
 int main(int argc, char *argv[]) {
   int myRank, numProcs;
 
-  int local_sum = 4;
-  int global_sum = 0;
+  int local_sum[5] = {4, 4, 4, 4, 4};
+  int global_sum[5] = {0};
 
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &numProcs);
   MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
 
   if (myRank == 0) {
-    MPI_Reduce(&local_sum, &global_sum, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(local_sum, global_sum, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
   } else {
-    MPI_Reduce(&local_sum, &global_sum, 5, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(local_sum, global_sum, 5, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
   }
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum);
+    printf("Result: %d", global_sum[0]);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/ArgError-MPIReduce-Count-3a.c
+++ b/micro-benches/0-level/coll/ArgError-MPIReduce-Count-3a.c
@@ -2,23 +2,26 @@
 #include <stddef.h>
 #include <stdio.h>
 /*
- * Wrong number of elements to receive in MPI_Allgather (num of elem send and recved do not match ). line 17
- *
+ * Reduce call attempts to read out of bounds. (line 20)
  */
 int main(int argc, char *argv[]) {
   int myRank, numProcs;
 
   int local_sum = 4;
-  int global_sum[2] = {0, 0};
+  int global_sum = 0;
 
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &numProcs);
   MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
 
-  MPI_Allgather(&local_sum, 1, MPI_INT, global_sum, 2, MPI_INT, MPI_COMM_WORLD);
+  if (myRank == 0) {
+    MPI_Reduce(&local_sum, &global_sum, 5, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+  } else {
+    MPI_Reduce(&local_sum, &global_sum, 5, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+  }
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum[0]);
+    printf("Result: %d", global_sum);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/ArgError-MPIScatter-Communicator-1.c
+++ b/micro-benches/0-level/coll/ArgError-MPIScatter-Communicator-1.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[]) {
 
   int root = 0;
 
-  MPI_Scatter(&local_sum, 1, MPI_DOUBLE, &global_sum, 1, MPI_INT, root, MPI_COMM_NULL);
+  MPI_Scatter(local_sum, 1, MPI_DOUBLE, &global_sum, 1, MPI_INT, root, MPI_COMM_NULL);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/coll/ArgError-MPIScatter-Communicator-2.c
+++ b/micro-benches/0-level/coll/ArgError-MPIScatter-Communicator-2.c
@@ -15,7 +15,7 @@ int main(int argc, char *argv[]) {
   int root = 0;
 
   MPI_Comm comm = NULL;
-  MPI_Scatter(&local_sum, 1, MPI_DOUBLE, &global_sum, 1, MPI_INT, root, comm);
+  MPI_Scatter(local_sum, 1, MPI_DOUBLE, &global_sum, 1, MPI_INT, root, comm);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/coll/ArgError-MPIScatter-Count-1.c
+++ b/micro-benches/0-level/coll/ArgError-MPIScatter-Count-1.c
@@ -2,19 +2,19 @@
 #include <stddef.h>
 #include <stdio.h>
 /*
- * Too many elements specified to send. (line 16)
+ * Scatter attempts to read out of bounds. (line 17)
  */
 int main(int argc, char *argv[]) {
   int myRank, numProcs;
 
   int local_sum[2] = {1, 1};
-  int global_sum = 0;
+  int global_sum[2] = {0, 0};
 
   MPI_Init(&argc, &argv);
 
   int root = 0;
 
-  MPI_Scatter(&local_sum, 2, MPI_INT, &global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Scatter(local_sum, 2, MPI_INT, &global_sum, 2, MPI_INT, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/coll/ArgError-MPIScatter-Count-1a.c
+++ b/micro-benches/0-level/coll/ArgError-MPIScatter-Count-1a.c
@@ -2,19 +2,19 @@
 #include <stddef.h>
 #include <stdio.h>
 /*
- * Illegal (negative) root is specified. (line 16)
+ * Scatter receive and send type signatures do not match. (line 17)
  */
 int main(int argc, char *argv[]) {
   int myRank, numProcs;
 
-  int local_sum[2] = {1, 1};
+  int local_sum[4] = {1, 1, 1, 1};
   int global_sum = 0;
 
   MPI_Init(&argc, &argv);
 
-  int root = -1;
+  int root = 0;
 
-  MPI_Scatter(local_sum, 1, MPI_INT, &global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Scatter(local_sum, 2, MPI_INT, &global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/coll/ArgError-MPIScatter-Count-2.c
+++ b/micro-benches/0-level/coll/ArgError-MPIScatter-Count-2.c
@@ -2,19 +2,19 @@
 #include <stddef.h>
 #include <stdio.h>
 /*
- * scatter has wrong number of elements for recv buffer. (line 16)
+ * Scatter has wrong number of elements for recv buffer. (line 16)
  */
 int main(int argc, char *argv[]) {
   int myRank, numProcs;
 
   int local_sum[2] = {1, 1};
-  int global_sum = 0;
+  int global_sum[3] = {0};
 
   MPI_Init(&argc, &argv);
 
   int root = 0;
 
-  MPI_Scatter(&local_sum, 1, MPI_INT, &global_sum, 3, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Scatter(local_sum, 1, MPI_INT, global_sum, 3, MPI_INT, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/coll/ArgError-MPIScatter-Count-3.c
+++ b/micro-benches/0-level/coll/ArgError-MPIScatter-Count-3.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[]) {
 
   int root = 0;
 
-  MPI_Scatter(&local_sum, -1, MPI_INT, &global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Scatter(local_sum, -1, MPI_INT, &global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/coll/ArgError-MPIScatter-Count-4.c
+++ b/micro-benches/0-level/coll/ArgError-MPIScatter-Count-4.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[]) {
 
   int root = 0;
 
-  MPI_Scatter(&local_sum, 1, MPI_INT, &global_sum, -1, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Scatter(local_sum, 1, MPI_INT, &global_sum, -1, MPI_INT, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/coll/ArgError-MPIScatter-RecvBuffer.c
+++ b/micro-benches/0-level/coll/ArgError-MPIScatter-RecvBuffer.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[]) {
 
   int root = 0;
 
-  MPI_Scatter(&local_sum, 1, MPI_INT, global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Scatter(local_sum, 1, MPI_INT, global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/coll/ArgError-MPIScatter-Type-1.c
+++ b/micro-benches/0-level/coll/ArgError-MPIScatter-Type-1.c
@@ -8,13 +8,13 @@ int main(int argc, char *argv[]) {
   int myRank, numProcs;
 
   int local_sum[2] = {1, 1};
-  int global_sum = 0;
+  double global_sum = 0.0;
 
   MPI_Init(&argc, &argv);
 
   int root = 0;
 
-  MPI_Scatter(&local_sum, 1, MPI_DOUBLE, &global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Scatter(local_sum, 1, MPI_DOUBLE, &global_sum, 1, MPI_DOUBLE, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/coll/ArgError-MPIScatter-Type-2.c
+++ b/micro-benches/0-level/coll/ArgError-MPIScatter-Type-2.c
@@ -7,14 +7,14 @@
 int main(int argc, char *argv[]) {
   int myRank, numProcs;
 
-  int local_sum[2] = {1, 1};
+  double local_sum[2] = {1.0, 1.0};
   int global_sum = 0;
 
   MPI_Init(&argc, &argv);
 
   int root = 0;
 
-  MPI_Scatter(&local_sum, 1, MPI_INT, &global_sum, 1, MPI_DOUBLE, root, MPI_COMM_WORLD);
+  MPI_Scatter(local_sum, 1, MPI_DOUBLE, &global_sum, 1, MPI_DOUBLE, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/coll/ArgError-MPIScatter-Type-3.c
+++ b/micro-benches/0-level/coll/ArgError-MPIScatter-Type-3.c
@@ -8,13 +8,13 @@ int main(int argc, char *argv[]) {
   int myRank, numProcs;
 
   int local_sum[2] = {1, 1};
-  int global_sum = 0;
+  unsigned int global_sum = 0;
 
   MPI_Init(&argc, &argv);
 
   int root = 0;
 
-  MPI_Scatter(&local_sum, 1, MPI_UNSIGNED, &global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Scatter(local_sum, 1, MPI_UNSIGNED, &global_sum, 1, MPI_UNSIGNED, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/coll/ArgMismatch-MPIReduce-Count.c
+++ b/micro-benches/0-level/coll/ArgMismatch-MPIReduce-Count.c
@@ -15,13 +15,13 @@ int main(int argc, char *argv[]) {
   MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
 
   if (myRank == 0) {
-    MPI_Reduce(&local_sum, &global_sum, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(local_sum, global_sum, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
   } else {
-    MPI_Reduce(&local_sum, &global_sum, 2, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(local_sum, global_sum, 2, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
   }
 
   if (myRank == 0) {
-    printf("Result: %d", global_sum);
+    printf("Result: %d", global_sum[0]);
   }
 
   MPI_Finalize();

--- a/micro-benches/0-level/coll/MisplacedCall-MPIBarrier-Deadlock-2.c
+++ b/micro-benches/0-level/coll/MisplacedCall-MPIBarrier-Deadlock-2.c
@@ -18,12 +18,12 @@ int main(int argc, char *argv[]) {
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
   if (rank == 0) {
-    MPI_Recv(&buffer, N, MPI_INT, 1, MSG_TAG_A, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+    MPI_Recv(buffer, N, MPI_INT, 1, MSG_TAG_A, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
     MPI_Barrier(MPI_COMM_WORLD);
-    MPI_Recv(&buffer2, N, MPI_INT, 1, MSG_TAG_B, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+    MPI_Recv(buffer2, N, MPI_INT, 1, MSG_TAG_B, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
   } else if (rank == 1) {
-    MPI_Send(&buffer, N, MPI_INT, 0, MSG_TAG_A, MPI_COMM_WORLD);
-    MPI_Send(&buffer2, N, MPI_INT, 0, MSG_TAG_B, MPI_COMM_WORLD);
+    MPI_Send(buffer, N, MPI_INT, 0, MSG_TAG_A, MPI_COMM_WORLD);
+    MPI_Send(buffer2, N, MPI_INT, 0, MSG_TAG_B, MPI_COMM_WORLD);
     MPI_Barrier(MPI_COMM_WORLD);
   }
 

--- a/micro-benches/0-level/conflo/coll/ArgError-MPIAllgather-SendCount.c
+++ b/micro-benches/0-level/conflo/coll/ArgError-MPIAllgather-SendCount.c
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
   } else {
     num_elements = 2;
   }
-  MPI_Allgather(&local_sum, num_elements, MPI_INT, &global_sum, 1, MPI_INT, MPI_COMM_WORLD);
+  MPI_Allgather(&local_sum, num_elements, MPI_INT, global_sum, 1, MPI_INT, MPI_COMM_WORLD);
 
   if (myRank == 0) {
     printf("Result: %d %d\n", global_sum[0], global_sum[1]);

--- a/micro-benches/0-level/conflo/coll/ArgError-MPIGather-Dest.c
+++ b/micro-benches/0-level/conflo/coll/ArgError-MPIGather-Dest.c
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
     root = 0;
   }
 
-  MPI_Gather(&local_sum, 1, MPI_INT, &global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Gather(&local_sum, 1, MPI_INT, global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/conflo/coll/ArgError-MPIGather-RecvCount.c
+++ b/micro-benches/0-level/conflo/coll/ArgError-MPIGather-RecvCount.c
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
   } else {
     num_elems = 1;
   }
-  MPI_Gather(&local_sum, 1, MPI_INT, &global_sum, num_elems, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Gather(&local_sum, 1, MPI_INT, global_sum, num_elems, MPI_INT, root, MPI_COMM_WORLD);
   MPI_Finalize();
 
   return 0;

--- a/micro-benches/0-level/conflo/coll/ArgError-MPIGather-RecvType.c
+++ b/micro-benches/0-level/conflo/coll/ArgError-MPIGather-RecvType.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
     recv_t = MPI_INT;
   }
 
-  MPI_Gather(&local_sum, 1, MPI_INT, &global_sum, 1, recv_t, root, MPI_COMM_WORLD);
+  MPI_Gather(&local_sum, 1, MPI_INT, global_sum, 1, recv_t, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/conflo/coll/ArgError-MPIGather-SendCount-1.c
+++ b/micro-benches/0-level/conflo/coll/ArgError-MPIGather-SendCount-1.c
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
   } else {
     num_elemns = 1;
   }
-  MPI_Gather(&local_sum, num_elemns, MPI_INT, &global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Gather(&local_sum, num_elemns, MPI_INT, global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/conflo/coll/ArgError-MPIGather-SendCount-2.c
+++ b/micro-benches/0-level/conflo/coll/ArgError-MPIGather-SendCount-2.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
     num_elems = 1;
   }
 
-  MPI_Gather(&local_sum, num_elems, MPI_INT, &global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Gather(&local_sum, num_elems, MPI_INT, global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/conflo/coll/ArgError-MPIGather-SendType.c
+++ b/micro-benches/0-level/conflo/coll/ArgError-MPIGather-SendType.c
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
     recv_t = MPI_INT;
   }
 
-  MPI_Gather(&local_sum, 1, recv_t, &global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
+  MPI_Gather(&local_sum, 1, recv_t, global_sum, 1, MPI_INT, root, MPI_COMM_WORLD);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIGet-SizeNotMatching.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIGet-SizeNotMatching.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
@@ -31,10 +31,10 @@ int main(int argc, char *argv[]) {
     }
     local_buf = malloc(size * sizeof(int));
 
-    MPI_Get(&local_buf, size, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Get(local_buf, size, MPI_INT, 1, 0, N, MPI_INT, win);
     free(local_buf);
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIGet-invalidAccess.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIGet-invalidAccess.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
@@ -29,10 +29,10 @@ int main(int argc, char *argv[]) {
     } else {
       acc_start = 0;
     }
-    MPI_Get(&local_buf, N, MPI_INT, 1, acc_start, N, MPI_INT, win);
+    MPI_Get(local_buf, N, MPI_INT, 1, acc_start, N, MPI_INT, win);
     // acces start at position 5 so it will be out of the tgt win
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIGet-type.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIGet-type.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
@@ -29,7 +29,7 @@ int main(int argc, char *argv[]) {
     } else {
       get_t = MPI_INT;
     }
-    MPI_Get(&local_buf, N, get_t, 1, 0, N, get_t, win);
+    MPI_Get(local_buf, N, get_t, 1, 0, N, get_t, win);
 
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIPut-InvalidAccess.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIPut-InvalidAccess.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
@@ -29,10 +29,10 @@ int main(int argc, char *argv[]) {
     } else {
       start_acc = 0;
     }
-    MPI_Put(&local_buf, N, MPI_INT, 1, start_acc, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, start_acc, N, MPI_INT, win);
     // acces start at position 5 so it will be out of the tgt win
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIPut-SizeNotMatching.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIPut-SizeNotMatching.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
@@ -35,7 +35,7 @@ int main(int argc, char *argv[]) {
 
     free(local_buf);
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIPut-buffer.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIPut-buffer.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIPut-count.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIPut-count.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
@@ -29,7 +29,7 @@ int main(int argc, char *argv[]) {
     } else {
       buf_size = N;
     }
-    MPI_Put(&local_buf, buf_size, MPI_INT, 1, 0, N * N, MPI_INT, win);
+    MPI_Put(local_buf, buf_size, MPI_INT, 1, 0, N * N, MPI_INT, win);
 
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIPut-rank.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIPut-rank.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
@@ -29,7 +29,7 @@ int main(int argc, char *argv[]) {
     } else {
       target_rank = 0;
     }
-    MPI_Put(&local_buf, N, MPI_INT, target_rank, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, target_rank, 0, N, MPI_INT, win);
 
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIPut-type.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIPut-type.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
@@ -29,7 +29,7 @@ int main(int argc, char *argv[]) {
     } else {
       put_t = MPI_INT;
     }
-    MPI_Put(&local_buf, N, put_t, 1, 0, N, put_t, win);
+    MPI_Put(local_buf, N, put_t, 1, 0, N, put_t, win);
 
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIWinCreate-OverwriteWin.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIWinCreate-OverwriteWin.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   MPI_Win win1, win2;
   MPI_Win *w_handler = &win1;
 
-  MPI_Win_create(&buffer, (N / 2) * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win1);
+  MPI_Win_create(buffer, (N / 2) * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win1);
 
   if (argc == 1) {
     w_handler = &win1;

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIWinCreate-dispUnit.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIWinCreate-dispUnit.c
@@ -25,7 +25,7 @@ int main(int argc, char *argv[]) {
     disp_unit = 1;
   }
 
-  MPI_Win_create(&buffer, N, disp_unit, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N, disp_unit, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   MPI_Win_free(&win);
 

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIWinCreate-overlap.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIWinCreate-overlap.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
 
   MPI_Win win1, win2;
 
-  MPI_Win_create(&buffer, (N / 2) * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win1);
+  MPI_Win_create(buffer, (N / 2) * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win1);
 
   // overlapping window is forbidden (windows overlap as sizeof(int) > 1 )
   int stride = 1;

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIWinCreate-size.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIWinCreate-size.c
@@ -26,7 +26,7 @@ int main(int argc, char *argv[]) {
     size = N;
   }
 
-  MPI_Win_create(&buffer, size, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, size, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   MPI_Win_free(&win);
   MPI_Finalize();

--- a/micro-benches/0-level/conflo/rma/ArgError-MPIWinFence-assert.c
+++ b/micro-benches/0-level/conflo/rma/ArgError-MPIWinFence-assert.c
@@ -18,12 +18,12 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
 
     int m_assert = MPI_MODE_NOPUT;
     if (argc == 1) {

--- a/micro-benches/0-level/conflo/rma/MisplacedCall-MPIGet-bufferModification.c
+++ b/micro-benches/0-level/conflo/rma/MisplacedCall-MPIGet-bufferModification.c
@@ -18,18 +18,18 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Get(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Get(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
 
     if (argc == 1) {
       local_buf[0] = 42;  // overwrite "receive buffer"
     }
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/conflo/rma/MisplacedCall-MPIPut-bufferModification.c
+++ b/micro-benches/0-level/conflo/rma/MisplacedCall-MPIPut-bufferModification.c
@@ -18,18 +18,18 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Get(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Get(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
 
     if (argc == 1) {
       local_buf[0] = 42;  // overwrite "send buffer"
     }
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/conflo/rma/MisplacedCall-MPIWinFence-1.c
+++ b/micro-benches/0-level/conflo/rma/MisplacedCall-MPIWinFence-1.c
@@ -18,14 +18,14 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     int local_buf[N] = {0};
     if (argc != 1) {
       MPI_Win_fence(0, win);
     }
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/conflo/rma/MisplacedCall-MPIWinFence-2.c
+++ b/micro-benches/0-level/conflo/rma/MisplacedCall-MPIWinFence-2.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
@@ -26,7 +26,7 @@ int main(int argc, char *argv[]) {
       MPI_Barrier(MPI_COMM_WORLD);
     }
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
 
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/conflo/rma/MisplacedCall-MPIWinFree-bufferFree.c
+++ b/micro-benches/0-level/conflo/rma/MisplacedCall-MPIWinFree-bufferFree.c
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (argc == 1) {
     free(buffer);

--- a/micro-benches/0-level/conflo/rma/MisplacedCall-MPIWinLock.c
+++ b/micro-benches/0-level/conflo/rma/MisplacedCall-MPIWinLock.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
@@ -27,7 +27,7 @@ int main(int argc, char *argv[]) {
     if (argc == 1) {
       MPI_Win_lock(MPI_LOCK_SHARED, 1, 0, win);
     }
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
     if (argc == 1) {
       MPI_Win_unlock(1, win);
     }

--- a/micro-benches/0-level/conflo/rma/MissingCall-MPIFence.c
+++ b/micro-benches/0-level/conflo/rma/MissingCall-MPIFence.c
@@ -18,14 +18,14 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     if (argc != 1) {
       MPI_Win_fence(0, win);
     }
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
     if (argc != 1) {
       MPI_Win_fence(0, win);
     }

--- a/micro-benches/0-level/conflo/rma/MissingCall-MPIWinCreate.c
+++ b/micro-benches/0-level/conflo/rma/MissingCall-MPIWinCreate.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
 
   MPI_Win win;
   if (rank == 0) {
-    MPI_Win_create(buffer, N, -1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+    MPI_Win_create(buffer, N * sizeof(int), -1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
     MPI_Win_free(&win);
   }

--- a/micro-benches/0-level/conflo/rma/MissingCall-MPIWinCreate.c
+++ b/micro-benches/0-level/conflo/rma/MissingCall-MPIWinCreate.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
 
   MPI_Win win;
   if (rank == 0) {
-    MPI_Win_create(&buffer, N, -1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+    MPI_Win_create(buffer, N, -1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
     MPI_Win_free(&win);
   }

--- a/micro-benches/0-level/conflo/rma/MissingCall-MPIWinFence-1.c
+++ b/micro-benches/0-level/conflo/rma/MissingCall-MPIWinFence-1.c
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/conflo/rma/MissingCall-MPIWinFence-2.c
+++ b/micro-benches/0-level/conflo/rma/MissingCall-MPIWinFence-2.c
@@ -18,12 +18,12 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
   } else {
     MPI_Win_fence(0, win);
   }

--- a/micro-benches/0-level/conflo/rma/MissingCall-MPIWinFence-3.c
+++ b/micro-benches/0-level/conflo/rma/MissingCall-MPIWinFence-3.c
@@ -18,11 +18,11 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
   } else {
   }
 

--- a/micro-benches/0-level/openmp/ordering/correct/two_collectives_3.c
+++ b/micro-benches/0-level/openmp/ordering/correct/two_collectives_3.c
@@ -7,7 +7,7 @@
 #include <unistd.h>
 
 /*
- * the user had to make shure only one collective initialization is active at a time per process and communicator
+ * the user had to make sure only one collective initialization is active at a time per process and communicator
  * according to the standard (see p303) If one reads the standard strictly, this is also forbidden with mixed
  * collectives
  */
@@ -30,18 +30,19 @@ int main(int argc, char *argv[]) {
   if (myRank == 0) {
 #pragma omp parallel num_threads(NUM_THREADS)
     {
-#pragma omp task
+#pragma omp single 
+    {
+#pragma omp task depend(inout: myRank)
       {
-#pragma omp critical
         MPI_Barrier(MPI_COMM_WORLD);
       }
-#pragma omp task
+#pragma omp task depend(inout: myRank)
       {
         int *buffer = malloc(BUFFER_LENGTH_BYTE);
-#pragma omp critical
         MPI_Bcast(buffer, BUFFER_LENGTH_INT, MPI_INT, 0, MPI_COMM_WORLD);
         free(buffer);
       }
+    }
     }  // end parallel
   }
 

--- a/micro-benches/0-level/openmp/ordering/two_collectives_3.c
+++ b/micro-benches/0-level/openmp/ordering/two_collectives_3.c
@@ -7,7 +7,7 @@
 #include <unistd.h>
 
 /*
- * the user had to make shure only one collective initialization is active at a time per process and communicator
+ * the user had to make sure only one collective initialization is active at a time per process and communicator
  * according to the standard (see p303) If one reads the standard strictly, this is also forbidden with mixed
  * collectives
  */
@@ -29,7 +29,6 @@ int main(int argc, char *argv[]) {
 
   const int other_rank = size - myRank - 1;
 
-  if (myRank == 0) {
 #pragma omp parallel num_threads(NUM_THREADS)
     {
 #pragma omp task
@@ -47,15 +46,6 @@ int main(int argc, char *argv[]) {
         free(buffer);
       }
     }  // end parallel
-  }
-
-  else {  // other MPI rank
-    usleep(5);
-    MPI_Barrier(MPI_COMM_WORLD);
-    int *buffer = malloc(BUFFER_LENGTH_BYTE);
-    MPI_Bcast(buffer, BUFFER_LENGTH_INT, MPI_INT, 0, MPI_COMM_WORLD);
-    free(buffer);
-  }
 
   has_error_manifested(overlap_count != 0);
   MPI_Finalize();

--- a/micro-benches/0-level/pt2pt/ArgError-MPIIRecv-Type-3a.c
+++ b/micro-benches/0-level/pt2pt/ArgError-MPIIRecv-Type-3a.c
@@ -6,7 +6,7 @@
 #define N 1000
 
 /*
- * Local and call data types do not match. line 25
+ * Send and recv type signatures do not match. line 25
  */
 
 int main(int argc, char *argv[]) {
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
   } else if (rank == 1) {
     MPI_Request req;
     MPI_Status stat;
-    MPI_Irecv(buffer, N, MPI_UNSIGNED, 0, MSG_TAG_A, MPI_COMM_WORLD, &req);
+    MPI_Irecv(buffer, N, MPI_INT, 0, MSG_TAG_A, MPI_COMM_WORLD, &req);
     MPI_Wait(&req, &stat);
   }
 

--- a/micro-benches/0-level/rma/ArgError-MPIGet-SizeNotMatching.c
+++ b/micro-benches/0-level/rma/ArgError-MPIGet-SizeNotMatching.c
@@ -18,14 +18,14 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
-    int local_buf[5] = {0};
-    MPI_Get(&local_buf, 5, MPI_INT, 1, 0, N, MPI_INT, win);
+    int local_buf[4] = {0};
+    MPI_Get(local_buf, 5, MPI_INT, 1, 0, N, MPI_INT, win);
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/rma/ArgError-MPIGet-buffer.c
+++ b/micro-benches/0-level/rma/ArgError-MPIGet-buffer.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/rma/ArgError-MPIGet-invalidAccess.c
+++ b/micro-benches/0-level/rma/ArgError-MPIGet-invalidAccess.c
@@ -18,15 +18,15 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Get(&local_buf, N, MPI_INT, 1, 5, N, MPI_INT, win);
-    // acces start at position 5 so it will be out of the tgt win
+    MPI_Get(local_buf, N, MPI_INT, 1, 5, N, MPI_INT, win);
+    // access start at position 5 so it will be out of the tgt win
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/rma/ArgError-MPIGet-rank.c
+++ b/micro-benches/0-level/rma/ArgError-MPIGet-rank.c
@@ -18,12 +18,12 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Get(&local_buf, N, MPI_INT, -1, 0, N, MPI_INT, win);
+    MPI_Get(local_buf, N, MPI_INT, -1, 0, N, MPI_INT, win);
 
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/rma/ArgError-MPIPut-InvalidAccess.c
+++ b/micro-benches/0-level/rma/ArgError-MPIPut-InvalidAccess.c
@@ -18,12 +18,12 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 5, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 5, N, MPI_INT, win);
     // acces start at position 5 so it will be out of the tgt win
 
     MPI_Win_fence(MPI_MODE_NOPRECEDE, win);

--- a/micro-benches/0-level/rma/ArgError-MPIPut-SizeNotMatching.c
+++ b/micro-benches/0-level/rma/ArgError-MPIPut-SizeNotMatching.c
@@ -18,14 +18,14 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, 10, MPI_INT, 1, 0, 5, MPI_INT, win);
+    MPI_Put(local_buf, 15, MPI_INT, 1, 0, 15, MPI_INT, win);
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/rma/ArgError-MPIPut-buffer.c
+++ b/micro-benches/0-level/rma/ArgError-MPIPut-buffer.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/rma/ArgError-MPIPut-count.c
+++ b/micro-benches/0-level/rma/ArgError-MPIPut-count.c
@@ -18,12 +18,12 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N * N, MPI_INT, 1, 0, N * N, MPI_INT, win);
+    MPI_Put(local_buf, N * N, MPI_INT, 1, 0, N * N, MPI_INT, win);
 
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/rma/ArgError-MPIPut-rank.c
+++ b/micro-benches/0-level/rma/ArgError-MPIPut-rank.c
@@ -18,12 +18,12 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, -1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, -1, 0, N, MPI_INT, win);
 
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/rma/ArgError-MPIWinCreate-OverwriteWin.c
+++ b/micro-benches/0-level/rma/ArgError-MPIWinCreate-OverwriteWin.c
@@ -15,14 +15,13 @@ int main(int argc, char *argv[]) {
   MPI_Comm_size(MPI_COMM_WORLD, &numProcs);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-  MPI_Win win1, win2;
+  MPI_Win win1;
 
-  MPI_Win_create(&buffer, (N / 2) * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win1);
+  MPI_Win_create(buffer, (N / 2) * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win1);
 
   MPI_Win_create(&buffer[N / 2], (N / 2) * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win1);
 
   MPI_Win_free(&win1);
-  MPI_Win_free(&win2);
 
   MPI_Finalize();
 

--- a/micro-benches/0-level/rma/ArgError-MPIWinCreate-dispUnit.c
+++ b/micro-benches/0-level/rma/ArgError-MPIWinCreate-dispUnit.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
 
   MPI_Win win;
 
-  MPI_Win_create(&buffer, N, -1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N, -1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   MPI_Win_free(&win);
 

--- a/micro-benches/0-level/rma/ArgError-MPIWinCreate-invalidBuffer-2.c
+++ b/micro-benches/0-level/rma/ArgError-MPIWinCreate-invalidBuffer-2.c
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <stdio.h>
 /*
- * invalid buffer (buffer on temporary stack mem will be feed at function exit) (line 13)
+ * invalid buffer (buffer on temporary stack mem will be freed at function exit) (line 14)
  *
  */
 
@@ -11,7 +11,7 @@
 void get_win(MPI_Win *win) {
   int buffer[N];
 
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, win);
 
   return;
 }

--- a/micro-benches/0-level/rma/ArgError-MPIWinCreate-overlap.c
+++ b/micro-benches/0-level/rma/ArgError-MPIWinCreate-overlap.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
 
   MPI_Win win1, win2;
 
-  MPI_Win_create(&buffer, (N / 2) * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win1);
+  MPI_Win_create(buffer, (N / 2) * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win1);
 
   // overlapping window is forbidden (windows overlap as sizeof(int) > 1 )
   MPI_Win_create(buffer + N / 2, (N / 2) * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win2);

--- a/micro-benches/0-level/rma/ArgError-MPIWinCreate-size.c
+++ b/micro-benches/0-level/rma/ArgError-MPIWinCreate-size.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
 
   MPI_Win win;
 
-  MPI_Win_create(&buffer, -1, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, -1, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   MPI_Win_free(&win);
   MPI_Finalize();

--- a/micro-benches/0-level/rma/ArgError-MPIWinFence-assert.c
+++ b/micro-benches/0-level/rma/ArgError-MPIWinFence-assert.c
@@ -18,14 +18,14 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/rma/ArgMismatch-MPIGet-type.c
+++ b/micro-benches/0-level/rma/ArgMismatch-MPIGet-type.c
@@ -18,12 +18,12 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Get(&local_buf, N, MPI_LONG_LONG_INT, 1, 0, N, MPI_LONG_LONG_INT, win);
+    MPI_Get(local_buf, N, MPI_LONG_LONG_INT, 1, 0, N, MPI_LONG_LONG_INT, win);
 
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/rma/ArgMismatch-MPIPut-type.c
+++ b/micro-benches/0-level/rma/ArgMismatch-MPIPut-type.c
@@ -18,12 +18,12 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_LONG_LONG_INT, 1, 0, N, MPI_LONG_LONG_INT, win);
+    MPI_Put(local_buf, N, MPI_LONG_LONG_INT, 1, 0, N, MPI_LONG_LONG_INT, win);
 
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/rma/MisplacedCall-MPIGet-bufferModification.c
+++ b/micro-benches/0-level/rma/MisplacedCall-MPIGet-bufferModification.c
@@ -18,16 +18,16 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Get(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Get(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
 
     local_buf[0] = 42;  // overwrite "receive buffer"
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/rma/MisplacedCall-MPIPut-bufferModification.c
+++ b/micro-benches/0-level/rma/MisplacedCall-MPIPut-bufferModification.c
@@ -18,16 +18,16 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Get(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Get(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
 
     local_buf[0] = 42;  // overwrite "send buffer"
 
-    MPI_Win_fence(MPI_MODE_NOPRECEDE, win);
+    MPI_Win_fence(0, win);
   } else {
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/rma/MisplacedCall-MPIWinFence-1.c
+++ b/micro-benches/0-level/rma/MisplacedCall-MPIWinFence-1.c
@@ -18,11 +18,11 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
     MPI_Win_fence(0, win);
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/rma/MisplacedCall-MPIWinFence-2.c
+++ b/micro-benches/0-level/rma/MisplacedCall-MPIWinFence-2.c
@@ -18,13 +18,13 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     MPI_Barrier(MPI_COMM_WORLD);
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
 
     MPI_Win_fence(0, win);
   } else {

--- a/micro-benches/0-level/rma/MisplacedCall-MPIWinFree-bufferFree.c
+++ b/micro-benches/0-level/rma/MisplacedCall-MPIWinFree-bufferFree.c
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   free(buffer);
   MPI_Win_free(&win);

--- a/micro-benches/0-level/rma/MisplacedCall-MPIWinLock.c
+++ b/micro-benches/0-level/rma/MisplacedCall-MPIWinLock.c
@@ -18,14 +18,14 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
 
     MPI_Win_lock(MPI_LOCK_SHARED, 1, 0, win);
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
     MPI_Win_unlock(1, win);
 
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/rma/MissingCall-MPIFence.c
+++ b/micro-benches/0-level/rma/MissingCall-MPIFence.c
@@ -18,11 +18,11 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
 
   } else {
   }

--- a/micro-benches/0-level/rma/MissingCall-MPIWinCreate.c
+++ b/micro-benches/0-level/rma/MissingCall-MPIWinCreate.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
 
   MPI_Win win;
   if (rank == 0) {
-    MPI_Win_create(&buffer, N, -1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+    MPI_Win_create(buffer, N, sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
     MPI_Win_free(&win);
   }

--- a/micro-benches/0-level/rma/MissingCall-MPIWinCreate.c
+++ b/micro-benches/0-level/rma/MissingCall-MPIWinCreate.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
 
   MPI_Win win;
   if (rank == 0) {
-    MPI_Win_create(buffer, N, sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+    MPI_Win_create(buffer, N * sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
     MPI_Win_free(&win);
   }

--- a/micro-benches/0-level/rma/MissingCall-MPIWinFence-1.c
+++ b/micro-benches/0-level/rma/MissingCall-MPIWinFence-1.c
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);

--- a/micro-benches/0-level/rma/MissingCall-MPIWinFence-2.c
+++ b/micro-benches/0-level/rma/MissingCall-MPIWinFence-2.c
@@ -18,12 +18,12 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     MPI_Win_fence(0, win);
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
   } else {
     MPI_Win_fence(0, win);
   }

--- a/micro-benches/0-level/rma/MissingCall-MPIWinFence-3.c
+++ b/micro-benches/0-level/rma/MissingCall-MPIWinFence-3.c
@@ -18,11 +18,11 @@ int main(int argc, char *argv[]) {
   int *buffer = malloc(N * sizeof(int));
 
   MPI_Win win;
-  MPI_Win_create(&buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+  MPI_Win_create(buffer, N * sizeof(int), 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
   if (rank == 0) {
     int local_buf[N] = {0};
-    MPI_Put(&local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
+    MPI_Put(local_buf, N, MPI_INT, 1, 0, N, MPI_INT, win);
   } else {
   }
 

--- a/micro-benches/0-level/usertypes/ArgError-MPISend-Type-4.c
+++ b/micro-benches/0-level/usertypes/ArgError-MPISend-Type-4.c
@@ -30,6 +30,7 @@ int main(int argc, char *argv[]) {
     MPI_Recv(buf, 1, two_ints, 0, MY_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
   }
 
+  MPI_Type_free(&two_ints);
   MPI_Finalize();
 
   free(buf);

--- a/micro-benches/0-level/usertypes/ArgMismatch-MPIRecv-Type-6.c
+++ b/micro-benches/0-level/usertypes/ArgMismatch-MPIRecv-Type-6.c
@@ -37,6 +37,7 @@ int main(int argc, char *argv[]) {
   if (my_rank == 0) {
     MPI_Send(buf, 1, col_t, 1, MY_TAG, MPI_COMM_WORLD);
   } else if (my_rank == 1) {
+    MPI_Type_free(&col_t);
     MPI_Type_vector(16, 2, 16, MPI_FLOAT, &col_t);
     MPI_Type_commit(&col_t);
     MPI_Recv(buf, 1, col_t, 0, MY_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);


### PR DESCRIPTION
During the integration of these testcases into the MUST test suite, some issues unrelated to the intention of the test became apparent.

The most common ones include:
- Using the address of a buffer instead of the buffer itself (Especially visible in RMA test cases)
- Attempting to print a pointer as an integer
- Invalid use of the `MPI_MODE_NOPRECEDE` assertion
- Resource leaks

Additionally, for some testcases a related issue was created at multiple points, such as both a local buffer and MPI datatype mismatch together with a type signature mismatch between ranks.
For these, the issues were split into multiple testcases.
These testcases can be considered a RFC.